### PR TITLE
Removed duplicate unique index from DeviceCodes

### DIFF
--- a/migrations/SqlServer/Migrations/PersistedGrantDb/20181128104555_RemoveDuplicateDeviceCodesIndex.Designer.cs
+++ b/migrations/SqlServer/Migrations/PersistedGrantDb/20181128104555_RemoveDuplicateDeviceCodesIndex.Designer.cs
@@ -4,14 +4,16 @@ using IdentityServer4.EntityFramework.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace SqlServer.Migrations.PersistedGrantDb
 {
     [DbContext(typeof(PersistedGrantDbContext))]
-    partial class PersistedGrantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181128104555_RemoveDuplicateDeviceCodesIndex")]
+    partial class RemoveDuplicateDeviceCodesIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/migrations/SqlServer/Migrations/PersistedGrantDb/20181128104555_RemoveDuplicateDeviceCodesIndex.cs
+++ b/migrations/SqlServer/Migrations/PersistedGrantDb/20181128104555_RemoveDuplicateDeviceCodesIndex.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace SqlServer.Migrations.PersistedGrantDb
+{
+    public partial class RemoveDuplicateDeviceCodesIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DeviceCodes_UserCode",
+                table: "DeviceCodes");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceCodes_UserCode",
+                table: "DeviceCodes",
+                column: "UserCode",
+                unique: true);
+        }
+    }
+}

--- a/src/Extensions/ModelBuilderExtensions.cs
+++ b/src/Extensions/ModelBuilderExtensions.cs
@@ -162,7 +162,6 @@ namespace IdentityServer4.EntityFramework.Extensions
                 codes.HasKey(x => new {x.UserCode});
 
                 codes.HasIndex(x => x.DeviceCode).IsUnique();
-                codes.HasIndex(x => x.UserCode).IsUnique();
             });
         }
 


### PR DESCRIPTION
I noticed this was flagged as a recommended action by Azure SQL Advisor - the unique index IX_DeviceCodes_UserCode is essentially a duplicate of the primary key, and is therefore superfluous.