### PR TITLE
Fixing GetAllResourcesAsync not populating the Properties collection for identity resources

### DIFF
--- a/src/Stores/ResourceStore.cs
+++ b/src/Stores/ResourceStore.cs
@@ -133,7 +133,9 @@ namespace IdentityServer4.EntityFramework.Stores
         public Task<Resources> GetAllResourcesAsync()
         {
             var identity = _context.IdentityResources
-              .Include(x => x.UserClaims);
+              .Include(x => x.UserClaims)
+              .Include(x => x.Properties)
+              .AsNoTracking();
 
             var apis = _context.ApiResources
                 .Include(x => x.Secrets)


### PR DESCRIPTION
Fixed to pick up the ```Properties``` collection for identity resources and added ```AsNoTracking```.